### PR TITLE
Add documentation Makefiles

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -13,6 +13,8 @@ jobs:
   docs-checks:
     uses: canonical/operator-workflows/.github/workflows/docs.yaml@main
     secrets: inherit
+    with:
+      linkcheck-fail-on-error: false
   integration-tests:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,16 @@ __pycache__/
 .mypy_cache
 *.egg-info/
 */*.rock
+
+# BEGIN VALE WORKFLOW IGNORE
+.vale/styles/*
+!.vale/styles/local
+!.vale/styles/config/
+
+.vale/styles/config/*
+!.vale/styles/config/vocabularies/
+
+.vale/styles/config/vocabularies/*
+!.vale/styles/config/vocabularies/local
+# END VALE WORKFLOW IGNORE
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,41 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Top-level Makefile
+# Delegates targets to Makefile.docs
+
+# ==============================================================================
+# Macros
+# ==============================================================================
+
+# Colors
+NO_COLOR=\033[0m
+CYAN_COLOR=\033[0;36m
+YELLOW_COLOR=\033[0;93m
+RED_COLOR=\033[0;91m
+
+msg = @printf '$(CYAN_COLOR)$(1)$(NO_COLOR)\n'
+errmsg = @printf '$(RED_COLOR)Error: $(1)$(NO_COLOR)\n' && exit 1
+
+# ==============================================================================
+# Core
+# ==============================================================================
+
+include Makefile.docs
+
+.PHONY: help 
+help: _list-targets ## Prints all available targets
+
+.PHONY: _list-targets
+_list-targets: ## This collects and prints all targets, ignore internal commands
+	$(call msg,Available targets:)
+	@awk -F'[:#]' '                                               \
+		/^[a-zA-Z0-9._-]+:([^=]|$$)/ {                            \
+			target = $$1;                                         \
+			comment = "";                                         \
+			if (match($$0, /## .*/))                              \
+				comment = substr($$0, RSTART + 3);                \
+			if (target != ".PHONY" && target !~ /^_/ && !seen[target]++) \
+				printf "  make %-20s $(YELLOW_COLOR)# %s$(NO_COLOR)\n", target, comment;    \
+		}' $(MAKEFILE_LIST) | sort
+

--- a/Makefile.docs
+++ b/Makefile.docs
@@ -1,0 +1,75 @@
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+# Minimal makefile for documentation
+#
+
+# Vale settings
+VALE_DIR ?= .vale
+PRAECEPTA_CONFIG 	?= .vale.ini
+DOCS_FILES 	?= docs/ README.md CONTRIBUTING.md
+
+HAS_VALE			:= $(shell command -v vale;)
+HAS_LYCHEE			:= $(shell command -v lychee;)
+
+# ==============================================================================
+# Docs Targets
+# ==============================================================================
+
+.PHONY: docs-check
+docs-check: vale lychee ## Run all Docs checks
+
+.PHONY: docs-clean
+docs-clean: vale-clean
+
+# ==============================================================================
+# Dependency Check Targets
+# ==============================================================================
+
+.PHONY: .check-vale
+.check-vale:
+ifndef HAS_VALE
+	$(call errmsg,'vale' is not installed. Please install it first) \
+	exit 1;
+endif
+
+.PHONY: .check-lychee
+.check-lychee:
+ifndef HAS_LYCHEE
+	$(call errmsg,'lychee' is not installed. Please install it first) \
+	exit 1;
+endif
+
+
+# ==============================================================================
+# Main Vale Targets
+# ==============================================================================
+
+.PHONY: vale-sync
+vale-sync: ## Download and install external Vale configuration sources
+	$(call msg,--- Syncing Vale styles... ---)
+	@vale sync
+
+.PHONY: vale
+vale: .check-vale vale-sync ## Run Vale checks on docs
+	$(call msg,--- Running Vale checks on "$(DOCS_FILES)"... ---)
+	@vale --config=$(PRAECEPTA_CONFIG) $(DOCS_FILES)
+
+# ==============================================================================
+# Main Lychee Targets
+# ==============================================================================
+
+.PHONY: lychee
+lychee: .check-lychee ## Run Lychee checks on docs
+	$(call msg,--- Running lychee checks on "$(LYCHEE_DOCS_FILES)"... ---)
+	@lychee $(DOCS_FILES)
+
+# ==============================================================================
+# Helper Targets
+# ==============================================================================
+
+.PHONY: vale-clean
+vale-clean:
+	$(call msg,--- Cleaning downloaded packages and ignored files from "$(VALE_DIR)"... ---)
+	@git clean -dfX $(VALE_DIR)
+


### PR DESCRIPTION
### Overview

Add Makefiles for documentation checks.

### Rationale

Provides contributors the ability to run Vale and Lychee checks locally.
Also set link checks in the GitHub workflow to not fail on error

### Juju events changes

None

### Module changes

None

### Library changes

None

### Checklist

- [X] The [charm style guide](https://documentation.ubuntu.com/juju/3.6/reference/charm/charm-development-best-practices/) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation for charmhub is updated
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [ ] The `docs/changelog.md` is updated with user-relevant changes.

<!-- Explanation for any unchecked items above -->
There are no documentation changes in this PR.
There are no user-relevant changes in this PR.