### PR TITLE
Revert "chore: update charm libraries (#21)"

### DIFF
--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -254,7 +254,7 @@ if TYPE_CHECKING:
 
 LIBID = "dc15fa84cef84ce58155fb84f6c6213a"
 LIBAPI = 0
-LIBPATCH = 23
+LIBPATCH = 22
 
 PYDEPS = ["cosl >= 0.0.50", "pydantic"]
 
@@ -263,6 +263,12 @@ DEFAULT_PEER_RELATION_NAME = "peers"
 
 logger = logging.getLogger(__name__)
 SnapEndpoint = namedtuple("SnapEndpoint", "owner, name")
+
+# Note: MutableMapping is imported from the typing module and not collections.abc
+# because subscripting collections.abc.MutableMapping was added in python 3.9, but
+# most of our charms are based on 20.04, which has python 3.8.
+
+_RawDatabag = MutableMapping[str, str]
 
 
 class TransportProtocolType(str, enum.Enum):
@@ -297,15 +303,6 @@ _tracing_receivers_ports = {
 }
 
 ReceiverProtocol = Literal["otlp_grpc", "otlp_http", "zipkin", "jaeger_thrift_http", "jaeger_grpc"]
-
-
-def _dedupe_list(items: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    """Deduplicate items in the list via object identity."""
-    unique_items = []
-    for item in items:
-        if item not in unique_items:
-            unique_items.append(item)
-    return unique_items
 
 
 class TracingError(Exception):
@@ -622,8 +619,7 @@ class COSAgentProvider(Object):
         refresh_events: Optional[List] = None,
         tracing_protocols: Optional[List[str]] = None,
         *,
-        scrape_configs: Optional[Union[List[dict], Callable[[], List[Dict[str, Any]]]]] = None,
-        extra_alert_groups: Optional[Callable[[], Dict[str, Any]]] = None,
+        scrape_configs: Optional[Union[List[dict], Callable]] = None,
     ):
         """Create a COSAgentProvider instance.
 
@@ -644,9 +640,6 @@ class COSAgentProvider(Object):
             scrape_configs: List of standard scrape_configs dicts or a callable
                 that returns the list in case the configs need to be generated dynamically.
                 The contents of this list will be merged with the contents of `metrics_endpoints`.
-            extra_alert_groups: A callable that returns a dict of alert rule groups in case the
-                alerts need to be generated dynamically. The contents of this dict will be merged
-                with generic and bundled alert rules.
         """
         super().__init__(charm, relation_name)
         dashboard_dirs = dashboard_dirs or ["./src/grafana_dashboards"]
@@ -655,7 +648,6 @@ class COSAgentProvider(Object):
         self._relation_name = relation_name
         self._metrics_endpoints = metrics_endpoints or []
         self._scrape_configs = scrape_configs or []
-        self._extra_alert_groups = extra_alert_groups or {}
         self._metrics_rules = metrics_rules_dir
         self._logs_rules = logs_rules_dir
         self._recursive = recurse_rules_dirs
@@ -699,11 +691,10 @@ class COSAgentProvider(Object):
 
     @property
     def _scrape_jobs(self) -> List[Dict]:
-        """Return a list of scrape_configs.
+        """Return a prometheus_scrape-like data structure for jobs.
 
         https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config
         """
-        # Optionally allow the charm to set the scrape_configs
         if callable(self._scrape_configs):
             scrape_configs = self._scrape_configs()
         else:
@@ -721,17 +712,17 @@ class COSAgentProvider(Object):
 
         scrape_configs = scrape_configs or []
 
+        # Augment job name to include the app name and a unique id (index)
+        for idx, scrape_config in enumerate(scrape_configs):
+            scrape_config["job_name"] = "_".join(
+                [self._charm.app.name, str(idx), scrape_config.get("job_name", "default")]
+            )
+
         return scrape_configs
 
     @property
     def _metrics_alert_rules(self) -> Dict:
-        """Return a dict of alert rule groups."""
-        # Optionally allow the charm to add the metrics_alert_rules
-        if callable(self._extra_alert_groups):
-            rules = self._extra_alert_groups()
-        else:
-            rules = {"groups": []}
-
+        """Use (for now) the prometheus_scrape AlertRules to initialize this."""
         alert_rules = AlertRules(
             query_type="promql", topology=JujuTopology.from_charm(self._charm)
         )
@@ -740,11 +731,7 @@ class COSAgentProvider(Object):
             generic_alert_groups.application_rules,
             group_name_prefix=JujuTopology.from_charm(self._charm).identifier,
         )
-
-        # NOTE: The charm could supply rules we implement in this method, so we deduplicate
-        rules["groups"] = _dedupe_list(rules["groups"] + alert_rules.as_dict()["groups"])
-
-        return rules
+        return alert_rules.as_dict()
 
     @property
     def _log_alert_rules(self) -> Dict:


### PR DESCRIPTION
This reverts commit ecb666130b8eef612ff8a83a91eaf8ad3b77ef47.

Applicable spec: <link>

### Overview

Revert `cos_agent` charm library to revision 22.

Fix: https://github.com/canonical/chrony-client-operator/issues/34

### Rationale

<!-- The reason the change is needed -->

### Juju events changes

<!-- Any changes to the juju events being observed (newly added, significantly modified or deleted) -->

### Module changes

<!-- Any high level changes to modules and why (Service, Observer, helper) -->

### Library changes

<!-- Any changes to charm libraries -->

### Checklist

- [x] The [charm style guide](https://documentation.ubuntu.com/juju/3.6/reference/charm/charm-development-best-practices/) was applied
- [x] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [x] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [x] The documentation for charmhub is updated
- [x] The PR is tagged with appropriate label (`urgent`, `trivial`, `senior-review-required`, `documentation`)
- [x] The `docs/changelog.md` is updated with user-relevant changes.

<!-- Explanation for any unchecked items above -->
