### PR TITLE
Increased the ChronyTrackingStaleMeasurement alert threshold

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-05-19
+
+* Increased the `ChronyTrackingStaleMeasurement` alert threshold from
+  30 minutes to 8 hours to reduce false positives.
+
 ## 2026-01-22
 
 * Bundle chrony_exporter inside the charm instead of installing it from

--- a/src/prometheus_alert_rules/chrony.rule
+++ b/src/prometheus_alert_rules/chrony.rule
@@ -22,7 +22,7 @@ groups:
             The last clock offset reported by Chrony on {{ $labels.instance }}
             has been {{ $value }} seconds, exceeding the 1 s threshold for over 1 hour.
       - alert: ChronyTrackingStaleMeasurement
-        expr: chrony_tracking_update_interval_seconds > 1800
+        expr: chrony_tracking_update_interval_seconds > 28800
         for: 1h
         labels:
           severity: critical
@@ -31,7 +31,7 @@ groups:
           description: |
             Chrony on {{ $labels.instance }} has not processed a new measurement
             for over 30 minutes. The current update interval is {{ $value }} seconds,
-            exceeding the 1800 s threshold for more than 1 hour.
+            exceeding the 8h threshold for more than 1 hour.
       - alert: ChronyHighStratum
         expr: chrony_tracking_stratum > 3
         for: 1h


### PR DESCRIPTION
#### What this PR does

Increased the `ChronyTrackingStaleMeasurement` alert threshold from 30 minutes to 8 hours to reduce false positives.

#### Why we need it

Fix: https://github.com/canonical/chrony-client-operator/issues/59

#### Checklist

- [x] I followed the [contributing guide](https://github.com/canonical/is-charms-contributing-guide)
- [x] I added or updated the documentation (if applicable)
- [x] I updated `docs/changelog.md` with user-relevant changes
- [x] I added a [change artifact](../docs/release-notes/template/docs/release-notes/template/_change-artifact-template.yaml) for user-relevant changes in `docs/release-notes/artifacts`. If no change artifact is necessary, I tagged the PR with the label `no-release-note`.
- [ ] I used AI to assist with preparing this PR
- [ ] I added or updated tests as needed (unit and integration)
- [ ] **If integration test modules are used:** I updated the workflow configuration  
      (e.g., in `.github/workflows/integration_tests.yaml`, ensure the `modules` list is correct)
- [ ] **If this is a Grafana dashboard:** I added a screenshot of the dashboard
- [ ] **If this is Terraform:** `terraform fmt` passes and `tflint` reports no errors
- [ ] **If this is Rockcraft:** I updated the version

<!--  
You can adjust the checklist to match the project.
 
If you are an AI assistant (e.g., GitHub Copilot, ChatGPT, Claude), follow these instructions when generating or completing PR descriptions:

1. Add a **Test plan** section explaining how the changes were tested, including any manual, unit, integration, or workflow tests.
2. Add a **Review focus** section highlighting tricky parts, important decisions, or areas needing human attention.
3. Identify and document any **potential breaking changes**.
4. Highlight any **new dependencies, APIs, modules, or workflow changes** introduced by this PR.
-->

